### PR TITLE
Make releases immutable and enforce dev-to-main promotions

### DIFF
--- a/.github/workflows/main-promotion.yml
+++ b/.github/workflows/main-promotion.yml
@@ -1,0 +1,29 @@
+name: Main Promotion
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  source-branch:
+    name: Require dev source
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject non-dev promotions
+        env:
+          BASE_BRANCH: ${{ github.base_ref }}
+          HEAD_BRANCH: ${{ github.head_ref }}
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          if [ "$BASE_BRANCH" != "main" ] \
+             || [ "$HEAD_BRANCH" != "dev" ] \
+             || [ "$HEAD_REPOSITORY" != "$REPOSITORY" ]; then
+            echo "::error::main only accepts pull requests from this repository's dev branch. Open feature work against dev first, then promote dev to main."
+            exit 1
+          fi
+          echo "Verified $HEAD_REPOSITORY:$HEAD_BRANCH → $BASE_BRANCH"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,13 +23,50 @@ concurrency:
 
 permissions:
   contents: write
+  pull-requests: read
 
 env:
   DOCKER_IMAGE: jhd3197/serverkit
 
 jobs:
+  promotion-gate:
+    name: Verify dev promotion
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require a merged dev to main pull request
+        uses: actions/github-script@v9
+        with:
+          script: |
+            if (context.eventName !== 'push' || context.ref !== 'refs/heads/main') {
+              core.info('Manual and tag-triggered releases do not use the branch promotion gate.');
+              return;
+            }
+
+            const { owner, repo } = context.repo;
+            const { data: pulls } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner,
+              repo,
+              commit_sha: context.sha,
+            });
+            const promotion = pulls.find((pull) => (
+              pull.merged_at
+              && pull.base.ref === 'main'
+              && pull.head.ref === 'dev'
+              && pull.head.repo?.full_name === `${owner}/${repo}`
+            ));
+
+            if (!promotion) {
+              core.setFailed(
+                'Releases from main require a merged pull request from this repository\'s dev branch.'
+              );
+              return;
+            }
+
+            core.info(`Verified dev → main promotion via PR #${promotion.number}.`);
+
   ci-gate:
     name: CI Gate
+    needs: promotion-gate
     uses: ./.github/workflows/backend-ci.yml
 
   version:
@@ -60,18 +97,29 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "Releasing ServerKit version: $VERSION"
 
+      - name: Require an unused release version
+        if: github.event_name != 'push' || github.ref_type != 'tag'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          if git show-ref --verify --quiet "refs/tags/$TAG"; then
+            echo "::error::Refusing to overwrite existing tag $TAG. Bump VERSION before promoting dev to main."
+            exit 1
+          fi
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "::error::Refusing to overwrite existing release $TAG. Bump VERSION before promoting dev to main."
+            exit 1
+          fi
+
       - name: Create and push tag
         if: github.event_name == 'push' && github.ref_type != 'tag'
         run: |
           TAG="${{ steps.version.outputs.tag }}"
-          if git rev-parse "$TAG" >/dev/null 2>&1; then
-            echo "Tag $TAG already exists, skipping"
-          else
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git tag -a "$TAG" -m "Release $TAG"
-            git push origin "$TAG"
-          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "refs/tags/$TAG"
 
   build-release:
     name: Build Release Tarball
@@ -211,12 +259,13 @@ jobs:
           cat checksums.txt
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.version.outputs.tag }}
           name: ServerKit ${{ needs.version.outputs.tag }}
           draft: false
           prerelease: ${{ github.event.inputs.prerelease == 'true' }}
+          overwrite_files: false
           files: |
             release/*
           body: |

--- a/.github/workflows/scripts-ci.yml
+++ b/.github/workflows/scripts-ci.yml
@@ -21,6 +21,8 @@ on:
       - 'install.sh'
       - 'uninstall.sh'
       - 'serverkit'
+      - '.github/workflows/main-promotion.yml'
+      - '.github/workflows/release.yml'
       - '.github/workflows/scripts-ci.yml'
   pull_request:
     branches: [main]
@@ -30,6 +32,8 @@ on:
       - 'install.sh'
       - 'uninstall.sh'
       - 'serverkit'
+      - '.github/workflows/main-promotion.yml'
+      - '.github/workflows/release.yml'
       - '.github/workflows/scripts-ci.yml'
   workflow_call:
 
@@ -77,6 +81,7 @@ jobs:
           bash scripts/test/test_cli.sh
           bash scripts/test/test_agent_install.sh
           bash scripts/test/test_stage.sh
+          bash scripts/test/test_release_workflow.sh
 
       - name: nginx -t smoke (shipped vhosts parse on a real nginx)
         run: |
@@ -188,6 +193,7 @@ jobs:
             bash scripts/test/test_cli.sh
             bash scripts/test/test_agent_install.sh
             bash scripts/test/test_stage.sh
+            bash scripts/test/test_release_workflow.sh
           '
 
   python-provisioning:

--- a/scripts/test/test_release_workflow.sh
+++ b/scripts/test/test_release_workflow.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Static regression guard for the feature -> dev -> main release path.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RELEASE="$ROOT/.github/workflows/release.yml"
+PROMOTION="$ROOT/.github/workflows/main-promotion.yml"
+failures=0
+
+expect_text() {
+    file="$1"
+    text="$2"
+    label="$3"
+    if grep -Fq -- "$text" "$file"; then
+        printf 'ok   %s\n' "$label"
+    else
+        printf 'FAIL %s\n' "$label" >&2
+        failures=$((failures + 1))
+    fi
+}
+
+expect_text "$PROMOTION" 'branches: [main]' \
+    'main promotion runs on pull requests targeting main'
+expect_text "$PROMOTION" 'HEAD_BRANCH: ${{ github.head_ref }}' \
+    'main promotion reads the pull request head branch safely'
+expect_text "$PROMOTION" '[ "$HEAD_BRANCH" != "dev" ]' \
+    'main promotion rejects heads other than dev'
+expect_text "$PROMOTION" '[ "$HEAD_REPOSITORY" != "$REPOSITORY" ]' \
+    'main promotion rejects a fork branch named dev'
+
+expect_text "$RELEASE" 'name: Verify dev promotion' \
+    'release verifies the merged promotion'
+expect_text "$RELEASE" 'listPullRequestsAssociatedWithCommit' \
+    'release resolves the pull request associated with the main commit'
+expect_text "$RELEASE" "pull.head.ref === 'dev'" \
+    'release only accepts a merged dev head'
+expect_text "$RELEASE" 'name: Require an unused release version' \
+    'release checks version immutability before tagging'
+expect_text "$RELEASE" 'Refusing to overwrite existing tag' \
+    'release fails instead of reusing an existing tag'
+expect_text "$RELEASE" 'Refusing to overwrite existing release' \
+    'release fails instead of reusing an existing release'
+expect_text "$RELEASE" 'overwrite_files: false' \
+    'release assets cannot be overwritten'
+
+if [ "$failures" -ne 0 ]; then
+    printf '\n%d release workflow guard assertion(s) failed\n' "$failures" >&2
+    exit 1
+fi
+
+printf '\nrelease workflow guards are intact\n'


### PR DESCRIPTION
This failure mode does not get a second chance. A feature branch reached `main` while `VERSION` still named an existing release, so the pipeline skipped tag creation and replaced assets that had already been published. This change turns the repository's intended `feature → dev → main` convention into two enforced gates: pull requests targeting `main` must come from the same repository's `dev` branch, and the release workflow independently verifies that the triggering commit came from a merged `dev → main` pull request. Version resolution now treats an existing tag or release as a hard error, while release uploads explicitly refuse to overwrite files. A static guard in Scripts CI keeps those protections from being quietly removed later.

<details>
<summary>Technical changes</summary>

- `.github/workflows/main-promotion.yml` adds the `Main Promotion / Require dev source` check for every pull request targeting `main`; it rejects feature branches, forks that happen to name a branch `dev`, and any base/head combination outside same-repository `dev → main`.
- `.github/workflows/release.yml` adds a `Verify dev promotion` preflight that resolves the pull request associated with a `main` push and stops the release unless it was a merged same-repository `dev → main` promotion.
- The release workflow gains `pull-requests: read` permission for the associated-PR lookup while retaining its existing release permissions.
- Version preflight now exits with an Actions error when either the resolved tag or GitHub Release already exists; tag creation no longer treats reuse as a successful no-op.
- `softprops/action-gh-release` moves to the Node 24-based v3 line and sets `overwrite_files: false`, providing a second immutability boundary at asset upload time.
- `.github/workflows/scripts-ci.yml` watches both release-policy workflows and runs a static regression guard on the local and cross-distro script paths.
- The release-policy guard ratchets the required source-branch checks, associated-PR lookup, tag/release refusal messages, and non-overwriting upload configuration.

</details>