### PR TITLE
Prevent tab overflow crashes during navigation

### DIFF
--- a/frontend/src/components/ErrorBoundary.jsx
+++ b/frontend/src/components/ErrorBoundary.jsx
@@ -16,7 +16,12 @@ export class ErrorBoundary extends Component {
 
     componentDidCatch(error, errorInfo) {
         this.setState({ errorInfo });
-        console.error('ErrorBoundary caught an error:', error, errorInfo);
+        // React already emits caught render failures in production. Keep the
+        // extra component-stack log for local debugging without duplicating
+        // the production console error users see.
+        if (import.meta.env.DEV) {
+            console.error('ErrorBoundary caught an error:', error, errorInfo);
+        }
         // Fire-and-forget report to the backend error tracker. Wrapped so
         // reporting can NEVER throw inside the boundary — reportClientError
         // already swallows network failures; this guards payload assembly.
@@ -34,6 +39,12 @@ export class ErrorBoundary extends Component {
         } catch { /* reporting must never break the boundary */ }
     }
 
+    componentDidUpdate(prevProps) {
+        if (this.state.hasError && prevProps.resetKey !== this.props.resetKey) {
+            this.setState({ hasError: false, error: null, errorInfo: null });
+        }
+    }
+
     handleRetry = () => {
         this.setState({ hasError: false, error: null, errorInfo: null });
         this.props.onRetry?.();
@@ -42,13 +53,15 @@ export class ErrorBoundary extends Component {
     render() {
         if (this.state.hasError) {
             return (
-                <div className="error-boundary">
-                    <div className="error-boundary-icon">
+                <div className="sk-error-state" role="alert">
+                    <div className="sk-error-state__icon">
                         <AlertTriangle size={32} />
                     </div>
-                    <h3>{t('common.error.title', 'Something went wrong')}</h3>
-                    <p className="error-boundary-message">
-                        {this.state.error?.message || t('common.error.unexpected', 'An unexpected error occurred')}
+                    <h3 className="sk-error-state__title">
+                        {t('common.error.title', 'Something went wrong')}
+                    </h3>
+                    <p className="sk-error-state__message">
+                        {t('common.error.unexpected', 'An unexpected error occurred')}
                     </p>
                     <button type="button" className="btn btn-primary" onClick={this.handleRetry}>
                         <RefreshCw size={14} />
@@ -88,12 +101,12 @@ export function ErrorState({
     }
 
     return (
-        <div className="error-state">
-            <div className="error-state-icon">
+        <div className="sk-error-state">
+            <div className="sk-error-state__icon">
                 <AlertTriangle size={32} />
             </div>
-            <h3 className="error-state-title">{title}</h3>
-            <p className="error-state-message">{errorMessage}</p>
+            <h3 className="sk-error-state__title">{title}</h3>
+            <p className="sk-error-state__message">{errorMessage}</p>
             {onRetry && (
                 <button type="button" className="btn btn-primary" onClick={onRetry}>
                     <RefreshCw size={14} />

--- a/frontend/src/components/ds/PageTopbar.jsx
+++ b/frontend/src/components/ds/PageTopbar.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import { NavLink, useLocation } from 'react-router-dom';
 import { MoreHorizontal } from 'lucide-react';
 import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover';
@@ -60,16 +60,22 @@ function matchTab(tab, path) {
 function TopbarTabs({ tabs, label }) {
     const location = useLocation();
     const [popoverOpen, setPopoverOpen] = useState(false);
+    const safeTabs = useMemo(
+        () => (Array.isArray(tabs) ? tabs : []).filter(
+            (tab) => tab && typeof tab.to === 'string' && tab.to.length > 0
+        ),
+        [tabs]
+    );
 
     const activeIndex = useMemo(
-        () => tabs.findIndex((t) => matchTab(t, location.pathname)),
-        [tabs, location.pathname]
+        () => safeTabs.findIndex((tab) => matchTab(tab, location.pathname)),
+        [safeTabs, location.pathname]
     );
 
     const getActiveIndex = useCallback(() => activeIndex, [activeIndex]);
 
     const { containerRef, itemRefs, moreBtnRef, hiddenIndices, hiddenSet } = useOverflowItems({
-        count: tabs.length,
+        count: safeTabs.length,
         gap: 2,
         moreWidth: 56,
         getActiveIndex,
@@ -82,20 +88,20 @@ function TopbarTabs({ tabs, label }) {
         // the visible segmented control that actually holds the tabs.
         <nav ref={containerRef} className="sk-topbar__tabs" aria-label={`${label} sections`}>
             <div className="sk-topbar__tabs-inner">
-                {tabs.map((t, i) => {
+                {safeTabs.map((tab, i) => {
                     const isHidden = hiddenSet.has(i);
                     return (
                         <NavLink
-                            key={t.to}
-                            to={t.to}
-                            end={t.end}
+                            key={tab.to}
+                            to={tab.to}
+                            end={tab.end}
                             ref={(el) => { itemRefs.current[i] = el; }}
                             className={({ isActive }) => cn('sk-topbar__tab', isActive && 'is-active')}
                             style={{ display: isHidden ? 'none' : undefined }}
                             data-overflow={isHidden ? 'hidden' : undefined}
                         >
-                            {t.icon}
-                            {t.label}
+                            {tab.icon}
+                            {tab.label}
                         </NavLink>
                     );
                 })}
@@ -115,18 +121,19 @@ function TopbarTabs({ tabs, label }) {
                         <PopoverContent align="end" sideOffset={6} className="ui-popover-content">
                             <div className="tabs-overflow-list">
                                 {hiddenIndices.map((idx) => {
-                                    const t = tabs[idx];
+                                    const tab = safeTabs[idx];
+                                    if (!tab) return null;
                                     return (
                                         <NavLink
-                                            key={t.to}
-                                            to={t.to}
-                                            end={t.end}
+                                            key={tab.to}
+                                            to={tab.to}
+                                            end={tab.end}
                                             className="tabs-overflow-item"
                                             data-state={idx === activeIndex ? 'active' : 'inactive'}
                                             onClick={() => setPopoverOpen(false)}
                                         >
-                                            {t.icon}
-                                            {t.label}
+                                            {tab.icon}
+                                            {tab.label}
                                         </NavLink>
                                     );
                                 })}

--- a/frontend/src/components/ui/tabs.jsx
+++ b/frontend/src/components/ui/tabs.jsx
@@ -92,6 +92,7 @@ const TabsList = React.forwardRef(({ className, children, ...props }, ref) => {
             <div className="tabs-overflow-list">
               {hiddenIndices.map((idx) => {
                 const child = childArray[idx];
+                if (!child) return null;
                 const triggerEl = itemRefs.current[idx];
                 const isActive = triggerEl?.dataset?.state === 'active';
                 return (

--- a/frontend/src/hooks/__tests__/useOverflowItems.test.mjs
+++ b/frontend/src/hooks/__tests__/useOverflowItems.test.mjs
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { sanitizeOverflowIndices } from '../useOverflowItems.js';
+
+test('drops stale overflow indexes when a route switches to fewer tabs', () => {
+    assert.deepEqual(sanitizeOverflowIndices([2, 4, 7, 9], 4), [2]);
+});
+
+test('rejects malformed and duplicate overflow indexes', () => {
+    assert.deepEqual(
+        sanitizeOverflowIndices([-1, 1, 1, 2.5, '2', 3, null], 4),
+        [1, 3]
+    );
+});
+
+test('returns no overflow indexes for an empty item list', () => {
+    assert.deepEqual(sanitizeOverflowIndices([0, 1], 0), []);
+});

--- a/frontend/src/hooks/useOverflowItems.js
+++ b/frontend/src/hooks/useOverflowItems.js
@@ -7,6 +7,24 @@ function arraysEqual(a, b) {
 }
 
 /**
+ * Keep overflow state safe while a shared tab layout switches to a shorter
+ * item list. Effects recompute after render, so consumers must not receive
+ * indexes that were valid for the previous route but are invalid now.
+ */
+export function sanitizeOverflowIndices(indices, count) {
+    if (!Array.isArray(indices) || !Number.isInteger(count) || count <= 0) return [];
+
+    const safe = [];
+    const seen = new Set();
+    for (const index of indices) {
+        if (!Number.isInteger(index) || index < 0 || index >= count || seen.has(index)) continue;
+        seen.add(index);
+        safe.push(index);
+    }
+    return safe;
+}
+
+/**
  * Tracks which child items overflow a container and should be collapsed into a
  * "More" menu. Items are greedily fit left-to-right; the active item is always
  * kept visible by rebuilding the visible set around it.
@@ -115,9 +133,20 @@ export function useOverflowItems({ count, itemRefs: externalItemRefs, gap = 8, m
         return () => ro.disconnect();
     }, [recompute]);
 
-    const hiddenSet = new Set(hiddenIndices);
+    // A route change can reduce `count` before the measurement effect updates
+    // state. Clamp synchronously so this render can never dereference a stale
+    // item index (most visible with wider translated labels).
+    const safeHiddenIndices = sanitizeOverflowIndices(hiddenIndices, count);
+    const hiddenSet = new Set(safeHiddenIndices);
 
-    return { containerRef, itemRefs, moreBtnRef, hiddenIndices, hiddenSet, recompute };
+    return {
+        containerRef,
+        itemRefs,
+        moreBtnRef,
+        hiddenIndices: safeHiddenIndices,
+        hiddenSet,
+        recompute,
+    };
 }
 
 export default useOverflowItems;

--- a/frontend/src/layouts/DashboardLayout.jsx
+++ b/frontend/src/layouts/DashboardLayout.jsx
@@ -16,6 +16,7 @@ import api from '../services/api';
 import SystemNotices from '../components/SystemNotices';
 import StagingBanner from '../components/StagingBanner';
 import DeployPill from '../components/DeployPill';
+import ErrorBoundary from '../components/ErrorBoundary';
 
 // The Automations extension (tramo) contributes /automations/edit/:slug with
 // layout:'full', so it's picked up dynamically via fullPagePaths below.
@@ -106,7 +107,9 @@ const DashboardLayout = () => {
                 )}
                 <main className={`main-content${isFullPageRoute ? ' main-content--full-page' : ''}`}>
                     {!isFullPageRoute && <SystemNotices />}
-                    <Outlet />
+                    <ErrorBoundary resetKey={location.pathname}>
+                        <Outlet />
+                    </ErrorBoundary>
                 </main>
                 <CommandPalette open={paletteOpen} onClose={() => setPaletteOpen(false)} />
                 <LogsDrawer />

--- a/frontend/src/layouts/TabGroupLayout.jsx
+++ b/frontend/src/layouts/TabGroupLayout.jsx
@@ -75,23 +75,27 @@ export default function TabGroupLayout({ tabs, groupId }) {
     // Dedup by `to` (core wins); optional numeric `order` picks the
     // insertion index, default appends at the end.
     const mergedTabs = useMemo(() => {
-        if (!groupId) return tabs;
+        const coreTabs = (Array.isArray(tabs) ? tabs : [])
+            .filter((tab) => tab && typeof tab.to === 'string' && tab.to.length > 0)
+            .map((tab) => ({ ...tab, label: translateLabel(translate, tab) }));
+
+        if (!groupId) return coreTabs;
         const extras = (contributedTabs || [])
-            .filter((t) => t && t.group === groupId && t.to && t.label)
-            .filter((t) => !tabs.some((core) => core.to === t.to))
-            .map((t) => ({
-                to: t.to,
+            .filter((tab) => tab && tab.group === groupId && tab.to && tab.label)
+            .filter((tab) => !coreTabs.some((core) => core.to === tab.to))
+            .map((tab) => ({
+                to: tab.to,
                 // An extension tab may declare `labelKey` beside `label`;
                 // core tabs already do. Same resolver either way.
-                label: translateLabel(translate, t),
-                end: !!t.end,
-                icon: contributedIcon(t.icon),
-                order: t.order,
+                label: translateLabel(translate, tab),
+                end: !!tab.end,
+                icon: contributedIcon(tab.icon),
+                order: tab.order,
             }));
-        if (!extras.length) return tabs;
-        const merged = [...tabs];
-        for (const t of extras) {
-            const { order, ...tab } = t;
+        if (!extras.length) return coreTabs;
+        const merged = [...coreTabs];
+        for (const extra of extras) {
+            const { order, ...tab } = extra;
             const idx = Number.isInteger(order)
                 ? Math.min(Math.max(order, 0), merged.length)
                 : merged.length;
@@ -112,7 +116,7 @@ export default function TabGroupLayout({ tabs, groupId }) {
     return (
         <div className="page-container page-container--full-bleed sk-tabgroup">
             <PageTopbar
-                navLabel={active.label}
+                navLabel={active?.label || translate('common.page', 'Page')}
                 tabs={mergedTabs}
                 actions={<>{actions}<span className="sk-topbar__chrome" ref={setChromeSlot} /></>}
             />

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -4,10 +4,13 @@ import './plugins/runtime/vendorShare'
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.jsx'
+import ErrorBoundary from './components/ErrorBoundary.jsx'
 import './styles/main.scss'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
     <React.StrictMode>
-        <App />
+        <ErrorBoundary>
+            <App />
+        </ErrorBoundary>
     </React.StrictMode>,
 )


### PR DESCRIPTION
The tab bar was holding onto yesterday's seating chart after the room had already changed. Moving between tabbed sections could leave stale overflow indexes behind, causing pages such as Services, Backups, and Domains to crash while rendering the More menu. This change makes overflow state safe at the shared hook boundary and adds defensive validation at both rendering sites. It also resolves core tab labels from the active locale at render time, so translated navigation stays current without making the overflow path fragile. Finally, dashboard routes now fail into a recoverable error state instead of taking the entire application shell down with them.

### Highlights

- Moving between tabbed pages no longer produces a blank screen.
- Translated tab labels update with the selected language and remain safe when they overflow.
- Unexpected page failures preserve the dashboard navigation and offer a retry action.

<details>
<summary>Technical changes</summary>

- `sanitizeOverflowIndices` clamps stale, malformed, duplicate, and out-of-range indexes synchronously before `useOverflowItems` exposes them to consumers.
- `TopbarTabs` normalizes routed tab definitions and skips a missing overflow entry instead of dereferencing its route.
- `TabsList` applies the same missing-child guard to the shared Radix tab overflow menu.
- `TabGroupLayout` validates core routes, resolves their `labelKey` values against the active locale, and safely handles an empty active-tab result.
- `DashboardLayout` wraps routed content in a path-resetting `ErrorBoundary`, while the application root retains a final fallback for failures outside dashboard routes.
- `ErrorBoundary` now uses the established error-state styles, resets after navigation, and limits the extra component-stack console report to development builds.

</details>
