### PR TITLE
Consolidate the shared error state

### DIFF
--- a/frontend/src/components/ErrorBoundary.jsx
+++ b/frontend/src/components/ErrorBoundary.jsx
@@ -1,7 +1,7 @@
 import { Component } from 'react';
-import { AlertTriangle, RefreshCw } from 'lucide-react';
 import api from '../services/api';
 import { t } from '../i18n/t';
+import ErrorState from './ErrorState';
 
 // Class-based Error Boundary for catching React errors
 export class ErrorBoundary extends Component {
@@ -53,68 +53,16 @@ export class ErrorBoundary extends Component {
     render() {
         if (this.state.hasError) {
             return (
-                <div className="sk-error-state" role="alert">
-                    <div className="sk-error-state__icon">
-                        <AlertTriangle size={32} />
-                    </div>
-                    <h3 className="sk-error-state__title">
-                        {t('common.error.title', 'Something went wrong')}
-                    </h3>
-                    <p className="sk-error-state__message">
-                        {t('common.error.unexpected', 'An unexpected error occurred')}
-                    </p>
-                    <button type="button" className="btn btn-primary" onClick={this.handleRetry}>
-                        <RefreshCw size={14} />
-                        {t('common.actions.tryAgain', 'Try again')}
-                    </button>
-                </div>
+                <ErrorState
+                    title={t('common.error.title', 'Something went wrong')}
+                    message={t('common.error.unexpected', 'An unexpected error occurred')}
+                    onRetry={this.handleRetry}
+                />
             );
         }
 
         return this.props.children;
     }
-}
-
-// Functional component for displaying API/fetch errors
-export function ErrorState({
-    title = t('common.error.failedToLoad', 'Failed to load'),
-    message,
-    error,
-    onRetry,
-    compact = false
-}) {
-    const errorMessage = message || error?.message
-        || t('common.error.loadingData', 'An error occurred while loading data');
-
-    if (compact) {
-        return (
-            <div className="error-state-compact">
-                <AlertTriangle size={16} />
-                <span>{errorMessage}</span>
-                {onRetry && (
-                    <button type="button" className="btn btn-ghost btn-sm" onClick={onRetry}>
-                        <RefreshCw size={14} /> {t('common.actions.retry', 'Retry')}
-                    </button>
-                )}
-            </div>
-        );
-    }
-
-    return (
-        <div className="sk-error-state">
-            <div className="sk-error-state__icon">
-                <AlertTriangle size={32} />
-            </div>
-            <h3 className="sk-error-state__title">{title}</h3>
-            <p className="sk-error-state__message">{errorMessage}</p>
-            {onRetry && (
-                <button type="button" className="btn btn-primary" onClick={onRetry}>
-                    <RefreshCw size={14} />
-                    {t('common.actions.tryAgain', 'Try again')}
-                </button>
-            )}
-        </div>
-    );
 }
 
 export default ErrorBoundary;

--- a/frontend/src/components/ErrorState.jsx
+++ b/frontend/src/components/ErrorState.jsx
@@ -12,14 +12,38 @@ import { t } from '@/i18n/t';
  *     onRetry={loadData}
  *   />
  */
-export function ErrorState({ title = 'Something went wrong', message, onRetry, className = '' }) {
+export function ErrorState({
+    title = t('common.error.failedToLoad', 'Failed to load'),
+    message,
+    error,
+    onRetry,
+    compact = false,
+    className = '',
+}) {
+    const errorMessage = message || error?.message
+        || t('common.error.loadingData', 'An error occurred while loading data');
+
+    if (compact) {
+        return (
+            <div className={`error-state-compact ${className}`.trim()} role="alert">
+                <AlertTriangle size={16} />
+                <span>{errorMessage}</span>
+                {onRetry && (
+                    <Button variant="ghost" size="sm" onClick={onRetry}>
+                        <RefreshCw size={14} /> {t('common.actions.retry', 'Retry')}
+                    </Button>
+                )}
+            </div>
+        );
+    }
+
     return (
-        <div className={`sk-error-state ${className}`.trim()}>
+        <div className={`sk-error-state ${className}`.trim()} role="alert">
             <div className="sk-error-state__icon">
                 <AlertTriangle size={32} />
             </div>
             <h3 className="sk-error-state__title">{title}</h3>
-            {message && <p className="sk-error-state__message">{message}</p>}
+            {errorMessage && <p className="sk-error-state__message">{errorMessage}</p>}
             {onRetry && (
                 <Button variant="outline" size="sm" onClick={onRetry}>
                     <RefreshCw size={14} /> {t('common.actions.tryAgain', 'Try again')}

--- a/frontend/src/plugins/sdk/index.js
+++ b/frontend/src/plugins/sdk/index.js
@@ -162,7 +162,8 @@ export {
 //     used by both the Git and WordPress surfaces; the backups protection
 //     panel embedded by both the Backups page and WordPress). Exposing them
 //     here pins their props as SDK contract — change them accordingly.
-export { default as ErrorBoundary, ErrorState } from '../../components/ErrorBoundary';
+export { default as ErrorBoundary } from '../../components/ErrorBoundary';
+export { default as ErrorState } from '../../components/ErrorState';
 export { DangerZone } from '../../components/DangerZone';
 export { default as ResourceAdvisory } from '../../components/ResourceAdvisory';
 export { default as PluginSlot } from '../../components/PluginSlot';


### PR DESCRIPTION
# Consolidate the shared error state

Two error-state implementations were one too many, especially on the path meant to rescue the UI from failures. This cleanup makes the existing shared `ErrorState` component the single presentation used by both the application boundary and extension SDK. The boundary retains its reporting, retry, and route-reset behavior while delegating the rendered fallback to the canonical component. Keeping one implementation avoids import ambiguity and prevents the two versions from drifting apart later.

<details>
<summary>Technical changes</summary>

- `ErrorBoundary` now renders `components/ErrorState.jsx` and removes its duplicate named `ErrorState` implementation.
- The extension SDK continues exporting both `ErrorBoundary` and `ErrorState`, with `ErrorState` now sourced from the canonical component module.
- The review follow-up commit carries `[skip version]` so merging it into `dev` does not advance the already-finalized 1.7.125 release number.

</details>
