### PR TITLE
fix(github): repair app manifest setup flow

### DIFF
--- a/backend/app/middleware/security.py
+++ b/backend/app/middleware/security.py
@@ -34,7 +34,7 @@ def register_security_headers(app: Flask):
                 "connect-src 'self' ws: wss: http://localhost:* http://127.0.0.1:*",
                 "frame-ancestors 'none'",
                 "base-uri 'self'",
-                "form-action 'self'",
+                "form-action 'self' https://github.com",
             ]
         else:
             csp_directives = [
@@ -46,7 +46,7 @@ def register_security_headers(app: Flask):
                 "connect-src 'self' ws: wss:",
                 "frame-ancestors 'none'",
                 "base-uri 'self'",
-                "form-action 'self'",
+                "form-action 'self' https://github.com",
             ]
         response.headers['Content-Security-Policy'] = '; '.join(csp_directives)
 

--- a/backend/app/services/source_connection_service.py
+++ b/backend/app/services/source_connection_service.py
@@ -110,6 +110,13 @@ class SourceConnectionService:
             'name': f'ServerKit {suffix}',
             'url': base_url,
             'redirect_url': redirect_uri,
+            # GitHub requires a webhook URL when the manifest subscribes to
+            # events. Keep delivery disabled until ServerKit has an app-level
+            # receiver; deployments configure their own webhooks separately.
+            'hook_attributes': {
+                'url': f'{base_url}/api/v1/source-connections/github/webhook',
+                'active': False,
+            },
             # Where GitHub sends the user after they install the app (also the
             # user-to-server OAuth callback, so install + authorize land here).
             'callback_urls': [f'{base_url}/connections/callback/github'],

--- a/backend/tests/test_github_app_manifest.py
+++ b/backend/tests/test_github_app_manifest.py
@@ -23,6 +23,10 @@ def test_build_manifest_shape_and_state(app):
         assert manifest['name'].startswith('ServerKit')
         assert manifest['url'] == 'https://panel.example'
         assert manifest['redirect_url'].endswith('/connections/github-app/callback')
+        assert manifest['hook_attributes'] == {
+            'url': 'https://panel.example/api/v1/source-connections/github/webhook',
+            'active': False,
+        }
         assert manifest['callback_urls'] == ['https://panel.example/connections/callback/github']
         assert manifest['default_permissions']['contents'] == 'read'
         assert manifest['request_oauth_on_install'] is True
@@ -35,6 +39,18 @@ def test_build_manifest_requires_urls(app):
     with app.test_request_context():
         with pytest.raises(ValueError):
             SC.build_github_app_manifest('', 'https://panel.example')
+
+
+def test_manifest_webhook_url_has_no_double_slash(app):
+    with app.test_request_context():
+        manifest, _, _ = SC.build_github_app_manifest(
+            'https://panel.example/connections/github-app/callback',
+            'https://panel.example/',
+        )
+
+        assert manifest['hook_attributes']['url'] == (
+            'https://panel.example/api/v1/source-connections/github/webhook'
+        )
 
 
 def _fake_conversion_response():

--- a/backend/tests/test_security_headers.py
+++ b/backend/tests/test_security_headers.py
@@ -1,4 +1,4 @@
-"""Proving tests — HSTS is gated on the operator's SSL choice.
+"""Proving tests for the panel's security headers.
 
 HTTPS is optional in ServerKit, so the panel must NOT advertise HSTS/preload
 (a hard-to-reverse browser commitment) unless the deployment actually
@@ -7,7 +7,19 @@ a proxy Flask can't tell real TLS from a Cloudflare-Flexible edge, so we trust
 the recorded choice rather than the request scheme.
 """
 
+from pathlib import Path
+
 import config as cfg
+import pytest
+
+
+PANEL_NGINX_CONFIGS = [
+    Path(__file__).resolve().parents[2] / 'nginx' / 'nginx.conf',
+    Path(__file__).resolve().parents[2]
+    / 'nginx'
+    / 'sites-available'
+    / 'serverkit.conf',
+]
 
 
 def _make_app(hsts_enabled, debug):
@@ -42,6 +54,27 @@ def test_hsts_absent_in_insecure_mode():
 def test_hsts_absent_in_debug_even_if_secure():
     r = _make_app(hsts_enabled=True, debug=True).test_client().get('/ping')
     assert 'Strict-Transport-Security' not in r.headers
+
+
+@pytest.mark.parametrize('debug', [False, True])
+def test_csp_allows_only_github_as_an_external_form_target(debug):
+    r = _make_app(hsts_enabled=False, debug=debug).test_client().get('/ping')
+    csp = r.headers['Content-Security-Policy']
+    form_action = next(
+        directive.strip()
+        for directive in csp.split(';')
+        if directive.strip().startswith('form-action ')
+    )
+
+    assert form_action == "form-action 'self' https://github.com"
+
+
+@pytest.mark.parametrize('config_path', PANEL_NGINX_CONFIGS)
+def test_panel_nginx_csp_allows_github_manifest_submission(config_path):
+    config = config_path.read_text()
+
+    assert "form-action 'self' https://github.com;" in config
+    assert "form-action 'self';" not in config
 
 
 def test_resolve_ssl_mode(monkeypatch):

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -111,7 +111,7 @@ http {
         add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
 
         # Content Security Policy
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' ws: wss:; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' ws: wss:; frame-ancestors 'none'; base-uri 'self'; form-action 'self' https://github.com;" always;
 
         # Connection limits
         limit_conn conn_limit 20;

--- a/nginx/sites-available/serverkit.conf
+++ b/nginx/sites-available/serverkit.conf
@@ -105,7 +105,7 @@ server {
     # Content Security Policy
     # Note: 'unsafe-inline'/'unsafe-eval' are kept because many SPAs need them.
     # Once your build is verified to work without inline scripts, remove them.
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' ws: wss:; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' ws: wss:; frame-ancestors 'none'; base-uri 'self'; form-action 'self' https://github.com;" always;
 
     # ═══════════════════════════════════════════════════════════════════════════
     # ServerKit frontend — served directly by host nginx from the built SPA


### PR DESCRIPTION
## Description

Fix the one-click GitHub App manifest registration flow in two places:

- Allow form submissions to the exact https://github.com origin in the panel CSP emitted by Flask and both shipped panel Nginx configurations. This permits the required manifest POST while retaining self and avoiding wildcards.
- Add the required hook_attributes.url to generated GitHub App manifests. The hook is initially inactive because ServerKit does not currently expose an app-level receiver for these global events; deployment-specific webhooks remain configured separately.
- Cover the manifest shape, trailing-slash normalization, Flask CSP, and shipped Nginx CSP with regression tests.

GitHub manifest reference: https://docs.github.com/en/apps/sharing-github-apps/registering-a-github-app-from-a-manifest?apiVersion=2022-11-28

## Related Issues

None.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement

## How Has This Been Tested?

- Python compilation for the changed service, middleware, and tests
- 16 focused backend tests passed
- Backend test-count ratchet passed: 4,929 collected against a 4,791 baseline
- Full backend suite: 4,720 passed, 205 skipped, 4 pre-existing macOS failures reproduced unchanged on upstream/dev
- Frontend lint passed with 0 errors; existing warnings remain unchanged
- Frontend production build passed
- Nginx smoke test skipped locally because Nginx is not installed; CI exercises the shipped configuration on Linux

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing tests related to this change pass locally